### PR TITLE
Removed white-space; replaced with tabs. Removed forward slash before panasonic-hbtn.ko

### DIFF
--- a/usr/local/src/panasonic-hbtn/Makefile
+++ b/usr/local/src/panasonic-hbtn/Makefile
@@ -3,10 +3,10 @@ obj-m = panasonic-hbtn.o
 KVERSION = $(shell uname -r)
 
 all:
-        make -C /lib/modules/$(KVERSION)/build M=$(PWD) modules
+	make -C /lib/modules/$(KVERSION)/build M=$(PWD) modules
 clean:
-        make -C /lib/modules/$(KVERSION)/build M=$(PWD) clean
+	make -C /lib/modules/$(KVERSION)/build M=$(PWD) clean
 install:
-        mkdir -p /lib/modules/$(KVERSION)/kernel/drivers/panasonic-hbtn/
-        cp $(PWD)/panasonic-hbtn.ko /lib/modules/$(KVERSION)/kernel/drivers/panasonic-hbtn/
-        echo "panasonic-hbtn" > /etc/modules-load.d/panasonic-hbtn.conf
+	mkdir -p /lib/modules/$(KVERSION)/kernel/drivers/panasonic-hbtn/
+	cp $(PWD)panasonic-hbtn.ko /lib/modules/$(KVERSION)/kernel/drivers/panasonic-hbtn/
+	echo "panasonic-hbtn" > /etc/modules-load.d/panasonic-hbtn.conf


### PR DESCRIPTION
Tested on Panasonic CF-C1 running Debian 8 with kernel 3.16.0-4-amd64.